### PR TITLE
Fix: Install system dependencies

### DIFF
--- a/.github/workflows/transifex-sync.yml
+++ b/.github/workflows/transifex-sync.yml
@@ -19,6 +19,7 @@ jobs:
 
     - name: "Install system dependencies"
       run: |
+        sudo apt-get update
         sudo apt-get install gettext libgettextpo-dev python3-dev python3-pip libffi-dev libxml2-dev libxslt-dev git
         pip install lxml gitpython PyGithub termcolor
 


### PR DESCRIPTION
Add an apt update to avoid this type of error:

```
 Err:5 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libxslt1.1 amd64 1.1.39-0exp1ubuntu0.24.04.1
  404  Not Found [IP: 20.106.104.242 80]
Ign:6 http://security.ubuntu.com/ubuntu noble-updates/main amd64 libxslt1-dev amd64 1.1.39-0exp1ubuntu0.24.04.1
Err:6 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libxslt1-dev amd64 1.1.39-0exp1ubuntu0.24.04.1
  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libx/libxslt/libxslt1.1_1.1.39-0exp1ubuntu0.24.04.1_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libx/libxslt/libxslt1-dev_1.1.39-0exp1ubuntu0.24.04.1_amd64.deb  404  Not Found [IP: 20.106.104.242 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 1173 kB in 1s (974 kB/s)
Error: Process completed with exit code 100.
```

Example: https://github.com/pluginsGLPI/order/actions/runs/14025534582/job/39273467698